### PR TITLE
Copilot/fix 11

### DIFF
--- a/client/src/renderer/src/components/SideNav.vue
+++ b/client/src/renderer/src/components/SideNav.vue
@@ -70,12 +70,6 @@ const isGameReady = (game: any): boolean => {
             {{ game.type }}
           </span>
           <span
-            v-if="!isGameReady(game)"
-            class="badge badge-warning"
-          >
-            Not Installed
-          </span>
-          <span
             v-if="isGameRunning(game.executable)"
             class="badge badge-accent"
           >

--- a/client/src/renderer/src/components/SideNav.vue
+++ b/client/src/renderer/src/components/SideNav.vue
@@ -14,6 +14,22 @@ const isSelectedGame = (gameId: number): boolean => {
 const isGameRunning = (executable: string): boolean => {
   return runningStore.isRunning(executable);
 };
+
+const isGameReady = (game: any): boolean => {
+  // For Steam games, assume they're ready if it's a steam game
+  // In the future, we could add Steam installation detection
+  if (game.type === 'steam') {
+    return true; // Could be enhanced to check if Steam is installed
+  }
+  
+  // For archive games, check if they're installed
+  if (game.type === 'archive') {
+    return game.isInstalled === true;
+  }
+  
+  // For other types, assume ready by default
+  return true;
+};
 </script>
 
 <template>
@@ -24,6 +40,7 @@ const isGameRunning = (executable: string): boolean => {
       class="flex gap-4 p-4 cursor-pointer"
       :class="{
         'bg-base-200': isSelectedGame(game.id),
+        'opacity-50': !isGameReady(game),
       }"
       @click="gameStore.selectGame(game.id)"
     >
@@ -32,6 +49,9 @@ const isGameRunning = (executable: string): boolean => {
         :src="serverAddressStore.serverAddress + game.icon"
         alt="game image"
         class="h-12 w-12"
+        :class="{
+          'grayscale': !isGameReady(game),
+        }"
       />
       <div v-else class="h-12 w-12"></div>
 
@@ -40,6 +60,7 @@ const isGameRunning = (executable: string): boolean => {
           class="font-bold"
           :class="{
             'text-primary': isSelectedGame(game.id),
+            'text-gray-400': !isGameReady(game),
           }"
         >
           {{ game.name }}
@@ -47,6 +68,12 @@ const isGameRunning = (executable: string): boolean => {
         <div class="flex gap-2 mt-1">
           <span class="badge" :class="game.type === 'archive' ? 'badge-secondary' : 'badge-primary'">
             {{ game.type }}
+          </span>
+          <span
+            v-if="!isGameReady(game)"
+            class="badge badge-warning"
+          >
+            Not Installed
           </span>
           <span
             v-if="isGameRunning(game.executable)"

--- a/client/src/renderer/src/stores/useGameStore.ts
+++ b/client/src/renderer/src/stores/useGameStore.ts
@@ -175,6 +175,11 @@ export const useGameStore = defineStore('game', {
         const safeName = game.gameID.replaceAll(' ', '-');
         isInstalled = await functions.isGameInstalled(safeName);
         logger.log(`Game ${game.name} is installed: ${isInstalled}`);
+      } else if (game.type === 'steam') {
+        // For Steam games, assume they're ready to play if Steam is available
+        // This could be enhanced to check if Steam is actually installed
+        isInstalled = true; 
+        logger.log(`Steam game ${game.name} assumed ready: ${isInstalled}`);
       }
       return { ...game, isInstalled };
     },


### PR DESCRIPTION
This pull request introduces enhancements to the game readiness logic and updates the UI to reflect whether games are ready to play. The changes primarily focus on adding a new `isGameReady` function to determine game readiness based on type and updating the visual indicators in the `SideNav.vue` component accordingly.

### Game readiness logic:

* [`client/src/renderer/src/components/SideNav.vue`](diffhunk://#diff-08d271bb02d756809946687f48a92488916691bb3f6595a63d0305199d3ef049R17-R32): Added the `isGameReady` function to determine if a game is ready to play based on its type (`steam`, `archive`, or others). Steam games are assumed ready by default, while archive games check for installation status. Other types are considered ready by default.

### UI updates for game readiness:

* [`client/src/renderer/src/components/SideNav.vue`](diffhunk://#diff-08d271bb02d756809946687f48a92488916691bb3f6595a63d0305199d3ef049R43): Updated the game list item to apply reduced opacity (`opacity-50`) for games that are not ready.
* [`client/src/renderer/src/components/SideNav.vue`](diffhunk://#diff-08d271bb02d756809946687f48a92488916691bb3f6595a63d0305199d3ef049R52-R54): Added grayscale styling to game icons (`grayscale`) for games that are not ready.
* [`client/src/renderer/src/components/SideNav.vue`](diffhunk://#diff-08d271bb02d756809946687f48a92488916691bb3f6595a63d0305199d3ef049R63): Updated game name styling to use gray text (`text-gray-400`) for games that are not ready.

### Steam game readiness assumption:

* [`client/src/renderer/src/stores/useGameStore.ts`](diffhunk://#diff-39db7a05e010973b0952e58567e62c3e6aae33e20638a6b34e2640e450b0a716R178-R182): Enhanced the `useGameStore` logic to assume Steam games are ready to play by default, logging this assumption. Future improvements could include checking for Steam installation.